### PR TITLE
吃三辺、吃四辺が正しく判定されていないのを修正

### DIFF
--- a/mjcore/yaku/catalog/sequence.cpp
+++ b/mjcore/yaku/catalog/sequence.cpp
@@ -1138,9 +1138,9 @@ void yaku::yakuCalculator::YakuCatalog::catalogInit::yakulst_sequence() {
 			for (int i = 1; i < SizeOfMeldBuffer; i++) {
 				for (int j = 0; j < TileSuitHonors; j += TileSuitStep) {
 					if ((analysis->MianziDat[i].mstat == meldSequenceExposedLower) &&
-						(analysis->MianziDat[i].tile == TileSuitStep + 7)) ++count;
+						(analysis->MianziDat[i].tile == j * TileSuitStep + 7)) ++count;
 					if ((analysis->MianziDat[i].mstat == meldSequenceExposedUpper) &&
-						(analysis->MianziDat[i].tile == TileSuitStep + 1)) ++count;
+						(analysis->MianziDat[i].tile == j * TileSuitStep + 1)) ++count;
 				}
 			}
 			return count;


### PR DESCRIPTION
リファクタリング中に発見したバグ。
コードをよく読むと筒子しか判定されていなかった。